### PR TITLE
Read and parse oobe completion timestamp

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,31 +1,116 @@
-# MSDN Code Gallery Microsoft Samples
+# Windows OOBE 完成时间戳读取器
 
-Thank you for your support and contributions over the years to the MSDN Code Gallery. The MSDN Code Gallery has officially retired and all MSDN Code Gallery pages now redirect to the [new code samples experience](https://docs.microsoft.com/samples).
+这个C++程序用于读取Windows注册表中的OOBE（Out-of-Box Experience）完成时间戳，并将其解析为可读的日期时间格式。
 
-We have archived the most actively engaged code samples to public archive repositories on GitHub which can be accessed via the links below:
+## 功能特性
 
-**Microsoft Samples**
-(samples are organized by product team)
-* [Microsoft Office Developer Documentation](https://github.com/microsoftarchive/msdn-code-gallery-microsoft/tree/master/Microsoft%20Office%20Developer%20Documentation%20Team)
-* [Windows Driver Kit](https://github.com/microsoftarchive/msdn-code-gallery-microsoft/tree/master/Official%20Windows%20Driver%20Kit%20Sample)
-* [Windows Platform](https://github.com/microsoftarchive/msdn-code-gallery-microsoft/tree/master/Official%20Windows%20Platform%20Sample)
-* [OneCode](https://github.com/microsoftarchive/msdn-code-gallery-microsoft/tree/master/OneCodeTeam)
-* [Visual Studio](https://github.com/microsoftarchive/msdn-code-gallery-microsoft/tree/master/Visual%20Studio%20Product%20Team)
-* [Windows Azure](https://github.com/microsoftarchive/msdn-code-gallery-microsoft/tree/master/Windows%20Azure%20Product%20Team)
+- 读取注册表键 `HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\OOBE\OOBECompleteTimestamp`
+- 解析前12字节的时间戳数据
+- 将每两字节解析为年、月、日、时、分、秒
+- 提供详细的错误处理和调试信息
+- 显示原始字节数据用于调试
 
-**Community Samples**
-(samples are organized in alphabetical order) 
-* [0-9, Non-Alphabet Characters](https://github.com/microsoftarchive/msdn-code-gallery-community-0-9-non-alphabetic)
-* [A-C](https://github.com/microsoftarchive/msdn-code-gallery-community-a-c)
-* [D-L](https://github.com/microsoftarchive/msdn-code-gallery-community-d-l)
-* [M-R](https://github.com/microsoftarchive/msdn-code-gallery-community-m-r)
-* [S-Z](https://github.com/microsoftarchive/msdn-code-gallery-community-s-z)
+## 编译方法
 
+### 使用 Microsoft Visual Studio
+```bash
+cl /EHsc registry_reader.cpp
+```
 
-## Extract Sample Zip and/or Git Clone
+### 使用 MinGW-w64
+```bash
+g++ -std=c++11 registry_reader.cpp -o registry_reader.exe
+```
 
-If you are experiencing issues extracting and/or using Git Clone for samples, you may need to enable **Win32 Long Paths**. This setting can be enabled in the Local Group Policy Editor within Computer Configuration\Administrative Templates\Symstem\Filesystem. Alternatively, you could download the zip file and use WinRAR to extract the file.
+### 使用 Clang
+```bash
+clang++ -std=c++11 registry_reader.cpp -o registry_reader.exe
+```
 
-## Contributing
+## 使用方法
 
-Support will not be provided for archived samples. You can find the most up to date code samples from Microsoft by visting our [new code samples browser](https://docs.microsoft.com/samples). Again, thank you for your generous support over the years!
+1. **以管理员权限运行程序**（推荐）
+   ```bash
+   # 右键点击命令提示符选择"以管理员身份运行"
+   registry_reader.exe
+   ```
+
+2. **或者以普通用户运行**
+   ```bash
+   registry_reader.exe
+   ```
+
+## 输出示例
+
+```
+正在读取OOBE完成时间戳...
+
+原始字节数据 (前12字节):
+字节 0-1: e4 07 (十进制: 2020)
+字节 2-3: 0c 00 (十进制: 12)
+字节 4-5: 1f 00 (十进制: 31)
+字节 6-7: 17 00 (十进制: 23)
+字节 8-9: 3b 00 (十进制: 59)
+字节 10-11: 3b 00 (十进制: 59)
+
+OOBE完成时间戳解析成功:
+年份: 2020
+月份: 12
+日期: 31
+小时: 23
+分钟: 59
+秒数: 59
+
+格式化时间: 2020-12-31 23:59:59
+```
+
+## 代码结构
+
+### `OOBETimestamp` 结构体
+存储解析后的时间戳组件：
+- `year`: 年份 (uint16_t)
+- `month`: 月份 (uint16_t) 
+- `day`: 日期 (uint16_t)
+- `hour`: 小时 (uint16_t)
+- `minute`: 分钟 (uint16_t)
+- `second`: 秒数 (uint16_t)
+
+### `RegistryReader` 类
+
+#### `ReadOOBECompleteTimestamp(OOBETimestamp& timestamp)`
+主要方法，用于读取和解析OOBE时间戳：
+- 打开注册表键
+- 读取 `OOBECompleteTimestamp` 值
+- 验证数据大小（至少12字节）
+- 解析前12字节为时间组件
+- 返回操作成功/失败状态
+
+#### `DisplayRawBytes()`
+调试方法，显示原始字节数据：
+- 以十六进制和十进制格式显示每两字节
+- 帮助理解数据格式和调试解析问题
+
+## 注意事项
+
+1. **管理员权限**: 虽然读取注册表通常不需要管理员权限，但某些系统配置可能需要提升权限。
+
+2. **数据格式假设**: 代码假设时间戳以小端序格式存储的16位整数。如果实际格式不同，可能需要调整解析逻辑。
+
+3. **错误处理**: 程序包含完整的错误处理，会显示具体的错误代码和描述。
+
+4. **兼容性**: 此程序仅适用于Windows系统，需要Windows API支持。
+
+## 可能的错误情况
+
+- **注册表键不存在**: 系统可能尚未完成OOBE设置
+- **权限不足**: 某些系统配置可能需要管理员权限
+- **数据格式不匹配**: 时间戳格式可能与预期不同
+- **数据大小不足**: 注册表值小于12字节
+
+## 扩展功能
+
+可以考虑添加的功能：
+- 支持不同的时间戳格式
+- 转换为标准的 `time_t` 格式
+- 支持批量读取多个OOBE相关的注册表值
+- 添加时间戳有效性验证

--- a/registry_reader.cpp
+++ b/registry_reader.cpp
@@ -1,0 +1,182 @@
+#include <windows.h>
+#include <iostream>
+#include <vector>
+#include <iomanip>
+
+struct OOBETimestamp {
+    uint16_t year;
+    uint16_t month;
+    uint16_t day;
+    uint16_t hour;
+    uint16_t minute;
+    uint16_t second;
+};
+
+class RegistryReader {
+public:
+    /**
+     * 读取注册表OOBE完成时间戳并解析为结构化时间
+     * @param timestamp 输出参数，解析后的时间戳结构
+     * @return true 成功，false 失败
+     */
+    static bool ReadOOBECompleteTimestamp(OOBETimestamp& timestamp) {
+        HKEY hKey;
+        LONG result;
+        
+        // 打开注册表键
+        result = RegOpenKeyExA(
+            HKEY_LOCAL_MACHINE,
+            "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\OOBE",
+            0,
+            KEY_READ,
+            &hKey
+        );
+        
+        if (result != ERROR_SUCCESS) {
+            std::cerr << "无法打开注册表键. 错误代码: " << result << std::endl;
+            return false;
+        }
+        
+        // 查询值的大小
+        DWORD dataSize = 0;
+        DWORD dataType = 0;
+        
+        result = RegQueryValueExA(
+            hKey,
+            "OOBECompleteTimestamp",
+            nullptr,
+            &dataType,
+            nullptr,
+            &dataSize
+        );
+        
+        if (result != ERROR_SUCCESS) {
+            std::cerr << "无法查询注册表值大小. 错误代码: " << result << std::endl;
+            RegCloseKey(hKey);
+            return false;
+        }
+        
+        // 确保至少有12字节的数据
+        if (dataSize < 12) {
+            std::cerr << "数据大小不足12字节. 实际大小: " << dataSize << " 字节" << std::endl;
+            RegCloseKey(hKey);
+            return false;
+        }
+        
+        // 读取注册表值
+        std::vector<BYTE> buffer(dataSize);
+        result = RegQueryValueExA(
+            hKey,
+            "OOBECompleteTimestamp",
+            nullptr,
+            &dataType,
+            buffer.data(),
+            &dataSize
+        );
+        
+        RegCloseKey(hKey);
+        
+        if (result != ERROR_SUCCESS) {
+            std::cerr << "无法读取注册表值. 错误代码: " << result << std::endl;
+            return false;
+        }
+        
+        // 解析前12字节，每两字节为一组
+        // 假设数据格式为小端序存储的16位整数
+        timestamp.year = *reinterpret_cast<uint16_t*>(&buffer[0]);
+        timestamp.month = *reinterpret_cast<uint16_t*>(&buffer[2]);
+        timestamp.day = *reinterpret_cast<uint16_t*>(&buffer[4]);
+        timestamp.hour = *reinterpret_cast<uint16_t*>(&buffer[6]);
+        timestamp.minute = *reinterpret_cast<uint16_t*>(&buffer[8]);
+        timestamp.second = *reinterpret_cast<uint16_t*>(&buffer[10]);
+        
+        return true;
+    }
+    
+    /**
+     * 显示原始字节数据（用于调试）
+     */
+    static void DisplayRawBytes() {
+        HKEY hKey;
+        LONG result;
+        
+        result = RegOpenKeyExA(
+            HKEY_LOCAL_MACHINE,
+            "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\OOBE",
+            0,
+            KEY_READ,
+            &hKey
+        );
+        
+        if (result != ERROR_SUCCESS) {
+            std::cerr << "无法打开注册表键进行调试显示" << std::endl;
+            return;
+        }
+        
+        DWORD dataSize = 0;
+        DWORD dataType = 0;
+        
+        result = RegQueryValueExA(hKey, "OOBECompleteTimestamp", nullptr, &dataType, nullptr, &dataSize);
+        
+        if (result == ERROR_SUCCESS && dataSize >= 12) {
+            std::vector<BYTE> buffer(dataSize);
+            result = RegQueryValueExA(hKey, "OOBECompleteTimestamp", nullptr, &dataType, buffer.data(), &dataSize);
+            
+            if (result == ERROR_SUCCESS) {
+                std::cout << "原始字节数据 (前12字节):" << std::endl;
+                for (int i = 0; i < 12 && i < static_cast<int>(dataSize); i += 2) {
+                    std::cout << "字节 " << i << "-" << (i+1) << ": ";
+                    std::cout << std::hex << std::setfill('0') << std::setw(2) 
+                              << static_cast<int>(buffer[i]) << " ";
+                    std::cout << std::hex << std::setfill('0') << std::setw(2) 
+                              << static_cast<int>(buffer[i+1]) << " ";
+                    std::cout << "(十进制: " << std::dec 
+                              << *reinterpret_cast<uint16_t*>(&buffer[i]) << ")" << std::endl;
+                }
+            }
+        }
+        
+        RegCloseKey(hKey);
+    }
+};
+
+// 使用示例
+int main() {
+    std::cout << "正在读取OOBE完成时间戳..." << std::endl;
+    
+    // 显示原始字节数据用于调试
+    RegistryReader::DisplayRawBytes();
+    std::cout << std::endl;
+    
+    OOBETimestamp timestamp;
+    
+    if (RegistryReader::ReadOOBECompleteTimestamp(timestamp)) {
+        std::cout << "OOBE完成时间戳解析成功:" << std::endl;
+        std::cout << "年份: " << timestamp.year << std::endl;
+        std::cout << "月份: " << timestamp.month << std::endl;
+        std::cout << "日期: " << timestamp.day << std::endl;
+        std::cout << "小时: " << timestamp.hour << std::endl;
+        std::cout << "分钟: " << timestamp.minute << std::endl;
+        std::cout << "秒数: " << timestamp.second << std::endl;
+        
+        // 格式化输出
+        std::cout << std::endl << "格式化时间: ";
+        std::cout << std::setfill('0') << std::setw(4) << timestamp.year << "-";
+        std::cout << std::setfill('0') << std::setw(2) << timestamp.month << "-";
+        std::cout << std::setfill('0') << std::setw(2) << timestamp.day << " ";
+        std::cout << std::setfill('0') << std::setw(2) << timestamp.hour << ":";
+        std::cout << std::setfill('0') << std::setw(2) << timestamp.minute << ":";
+        std::cout << std::setfill('0') << std::setw(2) << timestamp.second << std::endl;
+    } else {
+        std::cout << "读取OOBE完成时间戳失败" << std::endl;
+        std::cout << "请确保:" << std::endl;
+        std::cout << "1. 程序以管理员权限运行" << std::endl;
+        std::cout << "2. 注册表键存在" << std::endl;
+        std::cout << "3. 系统已完成OOBE设置" << std::endl;
+    }
+    
+    std::cout << std::endl << "按任意键退出...";
+    std::cin.get();
+    
+    return 0;
+}


### PR DESCRIPTION
Add a C++ program to read and parse the Windows OOBECompleteTimestamp registry value into year, month, day, hour, minute, and second components.

---
<a href="https://cursor.com/background-agent?bcId=bc-cd222116-c3f5-4ff5-8cbc-b048e93f68b0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-cd222116-c3f5-4ff5-8cbc-b048e93f68b0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

