### PR TITLE
Read and parse oobe completion timestamp

### DIFF
--- a/README_OOBE.md
+++ b/README_OOBE.md
@@ -1,0 +1,70 @@
+# OOBE 时间戳读取程序
+
+## 功能说明
+这个C++程序用于读取Windows注册表中的OOBE（Out-Of-Box Experience，开箱即用体验）完成时间戳。
+
+程序会读取以下注册表路径：
+```
+HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\OOBE\OOBECompleteTimestamp
+```
+
+并解析`OOBECompleteTimestamp`值的前12字节，按每2字节一组解析为：
+- 年（字节0-1）
+- 月（字节2-3）
+- 日（字节4-5）
+- 时（字节6-7）
+- 分（字节8-9）
+- 秒（字节10-11）
+
+## 编译方法
+
+### 使用Visual Studio命令行工具
+```bash
+cl /EHsc read_oobe_timestamp.cpp advapi32.lib
+```
+
+### 使用MinGW
+```bash
+g++ -o read_oobe_timestamp.exe read_oobe_timestamp.cpp -ladvapi32
+```
+
+### 使用Visual Studio IDE
+1. 创建一个新的Win32控制台应用程序项目
+2. 将代码复制到项目中
+3. 编译并运行
+
+## 使用方法
+
+**重要**：该程序需要管理员权限才能读取注册表。
+
+### 运行方式：
+1. 以管理员身份打开命令提示符
+2. 运行编译后的程序：
+```bash
+read_oobe_timestamp.exe
+```
+
+## 代码文件说明
+
+- `read_oobe_timestamp.cpp` - 完整版本，包含详细的错误处理和调试信息
+- `read_oobe_timestamp_method.cpp` - 简洁版本，只包含核心方法
+
+## 注意事项
+
+1. 程序使用Windows API，只能在Windows系统上编译和运行
+2. 需要链接`advapi32.lib`库（包含注册表相关API）
+3. 使用小端字节序解析数据（Windows默认）
+4. 如果注册表键不存在或数据格式不正确，程序会返回错误
+
+## 示例输出
+```
+OOBE完成时间:
+年: 2024
+月: 1
+日: 15
+时: 10
+分: 30
+秒: 45
+
+格式化时间: 2024-01-15 10:30:45
+```

--- a/read_oobe_timestamp.cpp
+++ b/read_oobe_timestamp.cpp
@@ -1,0 +1,118 @@
+#include <windows.h>
+#include <iostream>
+#include <iomanip>
+#include <vector>
+
+// 结构体用于存储解析后的时间信息
+struct OOBETimestamp {
+    WORD year;
+    WORD month;
+    WORD day;
+    WORD hour;
+    WORD minute;
+    WORD second;
+};
+
+// 读取并解析OOBE完成时间戳
+bool ReadOOBECompleteTimestamp(OOBETimestamp& timestamp) {
+    HKEY hKey;
+    LONG result;
+    
+    // 打开注册表键
+    const LPCWSTR keyPath = L"SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\OOBE\\OOBECompleteTimestamp";
+    result = RegOpenKeyExW(HKEY_LOCAL_MACHINE, keyPath, 0, KEY_READ, &hKey);
+    
+    if (result != ERROR_SUCCESS) {
+        std::cerr << "无法打开注册表键，错误代码: " << result << std::endl;
+        return false;
+    }
+    
+    // 准备读取数据
+    BYTE data[256];
+    DWORD dataSize = sizeof(data);
+    DWORD dataType;
+    
+    // 读取OOBECompleteTimestamp值
+    result = RegQueryValueExW(hKey, L"OOBECompleteTimestamp", NULL, &dataType, data, &dataSize);
+    
+    RegCloseKey(hKey);
+    
+    if (result != ERROR_SUCCESS) {
+        std::cerr << "无法读取注册表值，错误代码: " << result << std::endl;
+        return false;
+    }
+    
+    // 检查是否有足够的数据（至少12字节）
+    if (dataSize < 12) {
+        std::cerr << "数据大小不足，需要至少12字节，实际: " << dataSize << std::endl;
+        return false;
+    }
+    
+    // 解析前12字节，每2字节为一组
+    // 注意：Windows注册表通常使用小端字节序
+    timestamp.year   = *reinterpret_cast<WORD*>(&data[0]);
+    timestamp.month  = *reinterpret_cast<WORD*>(&data[2]);
+    timestamp.day    = *reinterpret_cast<WORD*>(&data[4]);
+    timestamp.hour   = *reinterpret_cast<WORD*>(&data[6]);
+    timestamp.minute = *reinterpret_cast<WORD*>(&data[8]);
+    timestamp.second = *reinterpret_cast<WORD*>(&data[10]);
+    
+    return true;
+}
+
+// 显示时间戳信息
+void DisplayTimestamp(const OOBETimestamp& timestamp) {
+    std::cout << "OOBE完成时间:" << std::endl;
+    std::cout << "年: " << timestamp.year << std::endl;
+    std::cout << "月: " << timestamp.month << std::endl;
+    std::cout << "日: " << timestamp.day << std::endl;
+    std::cout << "时: " << timestamp.hour << std::endl;
+    std::cout << "分: " << timestamp.minute << std::endl;
+    std::cout << "秒: " << timestamp.second << std::endl;
+    
+    // 格式化输出
+    std::cout << "\n格式化时间: " 
+              << std::setfill('0') 
+              << std::setw(4) << timestamp.year << "-"
+              << std::setw(2) << timestamp.month << "-"
+              << std::setw(2) << timestamp.day << " "
+              << std::setw(2) << timestamp.hour << ":"
+              << std::setw(2) << timestamp.minute << ":"
+              << std::setw(2) << timestamp.second << std::endl;
+}
+
+// 主函数示例
+int main() {
+    OOBETimestamp timestamp;
+    
+    if (ReadOOBECompleteTimestamp(timestamp)) {
+        DisplayTimestamp(timestamp);
+        
+        // 显示原始字节数据（用于调试）
+        std::cout << "\n原始字节数据（前12字节）:" << std::endl;
+        HKEY hKey;
+        if (RegOpenKeyExW(HKEY_LOCAL_MACHINE, 
+                         L"SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\OOBE\\OOBECompleteTimestamp", 
+                         0, KEY_READ, &hKey) == ERROR_SUCCESS) {
+            BYTE data[12];
+            DWORD dataSize = sizeof(data);
+            DWORD dataType;
+            
+            if (RegQueryValueExW(hKey, L"OOBECompleteTimestamp", NULL, &dataType, data, &dataSize) == ERROR_SUCCESS) {
+                for (int i = 0; i < 12; i++) {
+                    std::cout << std::hex << std::setw(2) << std::setfill('0') 
+                             << static_cast<int>(data[i]) << " ";
+                    if ((i + 1) % 2 == 0) std::cout << "| ";
+                }
+                std::cout << std::dec << std::endl;
+            }
+            RegCloseKey(hKey);
+        }
+    } else {
+        std::cerr << "读取OOBE时间戳失败！" << std::endl;
+        std::cerr << "请确保以管理员权限运行程序。" << std::endl;
+        return 1;
+    }
+    
+    return 0;
+}

--- a/read_oobe_timestamp_method.cpp
+++ b/read_oobe_timestamp_method.cpp
@@ -1,0 +1,77 @@
+#include <windows.h>
+#include <iostream>
+#include <vector>
+
+// 时间戳结构体
+struct OOBETimestamp {
+    WORD year;
+    WORD month;
+    WORD day;
+    WORD hour;
+    WORD minute;
+    WORD second;
+};
+
+/**
+ * 读取注册表HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\OOBE\OOBECompleteTimestamp
+ * 键的OOBECompleteTimestamp值，并解析前12字节为时间信息
+ * 
+ * @param timestamp 输出参数，存储解析后的时间信息
+ * @return 成功返回true，失败返回false
+ */
+bool ReadOOBECompleteTimestamp(OOBETimestamp& timestamp) {
+    HKEY hKey;
+    LONG result;
+    
+    // 打开注册表键
+    const LPCWSTR keyPath = L"SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\OOBE\\OOBECompleteTimestamp";
+    result = RegOpenKeyExW(HKEY_LOCAL_MACHINE, keyPath, 0, KEY_READ, &hKey);
+    
+    if (result != ERROR_SUCCESS) {
+        return false;
+    }
+    
+    // 准备读取数据
+    BYTE data[256];
+    DWORD dataSize = sizeof(data);
+    DWORD dataType;
+    
+    // 读取OOBECompleteTimestamp值
+    result = RegQueryValueExW(hKey, L"OOBECompleteTimestamp", NULL, &dataType, data, &dataSize);
+    
+    RegCloseKey(hKey);
+    
+    if (result != ERROR_SUCCESS || dataSize < 12) {
+        return false;
+    }
+    
+    // 解析前12字节，每2字节为一组
+    // 使用小端字节序（Windows默认）
+    timestamp.year   = *reinterpret_cast<WORD*>(&data[0]);
+    timestamp.month  = *reinterpret_cast<WORD*>(&data[2]);
+    timestamp.day    = *reinterpret_cast<WORD*>(&data[4]);
+    timestamp.hour   = *reinterpret_cast<WORD*>(&data[6]);
+    timestamp.minute = *reinterpret_cast<WORD*>(&data[8]);
+    timestamp.second = *reinterpret_cast<WORD*>(&data[10]);
+    
+    return true;
+}
+
+// 使用示例
+int main() {
+    OOBETimestamp timestamp;
+    
+    if (ReadOOBECompleteTimestamp(timestamp)) {
+        std::cout << "OOBE完成时间: "
+                  << timestamp.year << "-"
+                  << timestamp.month << "-"
+                  << timestamp.day << " "
+                  << timestamp.hour << ":"
+                  << timestamp.minute << ":"
+                  << timestamp.second << std::endl;
+    } else {
+        std::cerr << "读取失败，请确保以管理员权限运行" << std::endl;
+    }
+    
+    return 0;
+}


### PR DESCRIPTION
Add C++ code to read and parse the Windows `OOBECompleteTimestamp` registry value into year, month, day, hour, minute, and second components.

---
<a href="https://cursor.com/background-agent?bcId=bc-b5edac01-c4a0-43ae-a7d0-fca2a790a4fe">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b5edac01-c4a0-43ae-a7d0-fca2a790a4fe">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

